### PR TITLE
Removed the default scrollview from the MDDialog

### DIFF
--- a/kivymd/dialog.py
+++ b/kivymd/dialog.py
@@ -36,12 +36,10 @@ Builder.load_string('''
                 size_hint_y: None
                 text_size: self.width, None
                 height: self.texture_size[1]
-            ScrollView:
-                effect_cls: 'ScrollEffect'
-                BoxLayout:
-                    size_hint_y: None
-                    height: self.minimum_height
-                    id: container
+            BoxLayout:
+                size_hint_y: None
+                height: self.minimum_height
+                id: container
         AnchorLayout:
             anchor_x: 'right'
             anchor_y: 'center'


### PR DESCRIPTION
This scrollview only seems to be creating odd and unexpected behavior for the dialogs, and removing it doesn't seem to actually break anything.

It was added in [15916b2](https://github.com/AndreMiras/KivyMD/commit/15916b2b874e8fe17d77be1f05c2dca500722751#diff-1b2ddf6330817257b0263444bafde750) in order to deal with "lengthy content" - but that should probably be dealt with on the user side instead? 