### PR TITLE
Add self.thumb_color_disabled for MDSwitch non-Dark theme

### DIFF
--- a/kivymd/selectioncontrols.py
+++ b/kivymd/selectioncontrols.py
@@ -220,6 +220,8 @@ class MDSwitch(ThemableBehavior, ButtonBehavior, FloatLayout):
             self._track_color_active[3] = .5
             self._track_color_disabled = self.theme_cls.disabled_hint_text_color
             self.thumb_color_down = self.theme_cls.primary_color
+            self.thumb_color_disabled = get_color_from_hex(
+                colors['Grey']['400'])
 
     def on_pos(self, *args):
         if self.active:


### PR DESCRIPTION
Added, in _set_colors, setting self.thumb_color_disabled for MDSwitch when a non-Dark theme is being used.
Fixes old issue https://gitlab.com/kivymd/KivyMD/issues/99
Otherwise, code crashes when an MDSwitch is set to 'disabled'.